### PR TITLE
hotfix: make Number and DateTime interfaces public

### DIFF
--- a/cluster/pom.xml
+++ b/cluster/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.pragmatica-lite</groupId>
         <artifactId>pragmatica-lite</artifactId>
-        <version>0.7.19</version>
+        <version>0.7.20</version>
     </parent>
 
     <artifactId>cluster</artifactId>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.pragmatica-lite</groupId>
         <artifactId>pragmatica-lite</artifactId>
-        <version>0.7.19</version>
+        <version>0.7.20</version>
     </parent>
 
     <artifactId>common</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>pragmatica-lite</artifactId>
         <groupId>org.pragmatica-lite</groupId>
-        <version>0.7.19</version>
+        <version>0.7.20</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/core/src/main/java/org/pragmatica/lang/parse/DateTime.java
+++ b/core/src/main/java/org/pragmatica/lang/parse/DateTime.java
@@ -22,7 +22,7 @@ import java.time.*;
 import java.time.format.DateTimeFormatter;
 
 /// Functional wrappers for Java Time API parsing methods that return Result<T> instead of throwing exceptions
-sealed interface DateTime {
+public sealed interface DateTime {
     /// Parse a string as a LocalDate value using ISO format
     /// - **text**: String to parse
     /// - **Returns**: Result containing parsed LocalDate or parsing error

--- a/core/src/main/java/org/pragmatica/lang/parse/Number.java
+++ b/core/src/main/java/org/pragmatica/lang/parse/Number.java
@@ -22,7 +22,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 
 /// Functional wrappers for JDK number parsing APIs that return Result<T> instead of throwing exceptions
-sealed interface Number {
+public sealed interface Number {
     /// Parse a string as a Byte value
     /// - **s**: String to parse
     /// - **Returns**: Result containing parsed Byte or parsing error

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.pragmatica-lite</groupId>
         <artifactId>pragmatica-lite</artifactId>
-        <version>0.7.19</version>
+        <version>0.7.20</version>
     </parent>
 
     <artifactId>examples</artifactId>

--- a/net-core/pom.xml
+++ b/net-core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.pragmatica-lite</groupId>
         <artifactId>pragmatica-lite</artifactId>
-        <version>0.7.19</version>
+        <version>0.7.20</version>
     </parent>
 
     <artifactId>net-core</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.pragmatica-lite</groupId>
     <artifactId>pragmatica-lite</artifactId>
-    <version>0.7.19</version>
+    <version>0.7.20</version>
     <modules>
         <module>core</module>
         <module>examples</module>


### PR DESCRIPTION
## Summary
- Make Number and DateTime interfaces public for external package access
- Bump version from 0.7.19 to 0.7.20

## Changes
- Added `public` modifier to `sealed interface Number`
- Added `public` modifier to `sealed interface DateTime`
- Version bump to reflect API visibility change

## Urgency
Critical hotfix to enable access to parser interfaces from external packages