### PR TITLE
Release 0.11.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.2] - 2026-01-27
+
+### Added
+- **Spacer-based route disambiguation** in HTTP routing:
+  - `PathParameter.spacer(String)` creates literal path segment matchers
+  - Routes with same base path but different spacers can coexist (e.g., `/users/{id}/edit` vs `/users/{id}/delete`)
+  - `Route.spacers()` returns list of literal segments for route matching
+  - `RequestRouter` selects routes by matching spacers, with fallback to routes without spacers
+
+### Changed
+- **jbct-maven-plugin** updated to 0.5.0
+
+### Fixed
+- **Path parameter parsing edge cases** in `RequestContextImpl`:
+  - Properly handles paths with/without leading slashes after base path
+  - Correctly handles empty remainders and trailing slashes
+
 ## [0.11.1] - 2026-01-26
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![License](https://img.shields.io/badge/license-Apache%202-blue.svg)
 ![Java](https://img.shields.io/badge/Java-25-orange.svg)
-![Maven Central](https://img.shields.io/badge/Maven-0.11.1-blue.svg)
+![Maven Central](https://img.shields.io/badge/Maven-0.11.2-blue.svg)
 
 ## Modern Functional Programming for Java 25
 
@@ -93,14 +93,14 @@ Pragmatica Lite is available on Maven Central. Simply add the dependency to your
 <dependency>
     <groupId>org.pragmatica-lite</groupId>
     <artifactId>core</artifactId>
-    <version>0.11.1</version>
+    <version>0.11.2</version>
 </dependency>
 ```
 
 For Gradle users:
 
 ```gradle
-implementation 'org.pragmatica-lite:core:0.11.1'
+implementation 'org.pragmatica-lite:core:0.11.2'
 ```
 
 ### Your First Pragmatica Application
@@ -213,7 +213,7 @@ Serialize and deserialize Result, Option, and Promise types:
 <dependency>
     <groupId>org.pragmatica-lite</groupId>
     <artifactId>jackson</artifactId>
-    <version>0.11.1</version>
+    <version>0.11.2</version>
 </dependency>
 ```
 
@@ -241,7 +241,7 @@ Promise-based JPA operations with typed errors:
 <dependency>
     <groupId>org.pragmatica-lite</groupId>
     <artifactId>jpa</artifactId>
-    <version>0.11.1</version>
+    <version>0.11.2</version>
 </dependency>
 ```
 
@@ -273,7 +273,7 @@ Monitor Result, Option, and Promise operations:
 <dependency>
     <groupId>org.pragmatica-lite</groupId>
     <artifactId>micrometer</artifactId>
-    <version>0.11.1</version>
+    <version>0.11.2</version>
 </dependency>
 ```
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>pragmatica-lite</artifactId>
         <groupId>org.pragmatica-lite</groupId>
-        <version>0.11.1</version>
+        <version>0.11.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.pragmatica-lite</groupId>
         <artifactId>pragmatica-lite</artifactId>
-        <version>0.11.1</version>
+        <version>0.11.2</version>
     </parent>
 
     <artifactId>examples</artifactId>

--- a/integrations/config/pom.xml
+++ b/integrations/config/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>integrations</artifactId>
         <groupId>org.pragmatica-lite</groupId>
-        <version>0.11.1</version>
+        <version>0.11.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integrations/config/toml/README.md
+++ b/integrations/config/toml/README.md
@@ -8,7 +8,7 @@ Zero-dependency TOML parser with Result-based error handling and Option-based ac
 <dependency>
     <groupId>org.pragmatica-lite</groupId>
     <artifactId>toml</artifactId>
-    <version>0.11.1</version>
+    <version>0.11.2</version>
 </dependency>
 ```
 

--- a/integrations/config/toml/pom.xml
+++ b/integrations/config/toml/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>config</artifactId>
         <groupId>org.pragmatica-lite</groupId>
-        <version>0.11.1</version>
+        <version>0.11.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integrations/consensus/pom.xml
+++ b/integrations/consensus/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>integrations</artifactId>
         <groupId>org.pragmatica-lite</groupId>
-        <version>0.11.1</version>
+        <version>0.11.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integrations/consensus/src/main/java/org/pragmatica/consensus/leader/LeaderManager.java
+++ b/integrations/consensus/src/main/java/org/pragmatica/consensus/leader/LeaderManager.java
@@ -21,11 +21,14 @@ import org.pragmatica.consensus.topology.QuorumStateNotification;
 import org.pragmatica.consensus.topology.TopologyChangeNotification.NodeAdded;
 import org.pragmatica.consensus.topology.TopologyChangeNotification.NodeDown;
 import org.pragmatica.consensus.topology.TopologyChangeNotification.NodeRemoved;
+import org.pragmatica.lang.Option;
+import org.pragmatica.lang.Promise;
+import org.pragmatica.lang.Unit;
 import org.pragmatica.messaging.MessageReceiver;
 import org.pragmatica.messaging.MessageRouter;
-import org.pragmatica.lang.Option;
 
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.pragmatica.consensus.leader.LeaderNotification.leaderChange;
@@ -33,6 +36,12 @@ import static org.pragmatica.consensus.leader.LeaderNotification.leaderChange;
 /// Leader manager is responsible for choosing which node is the leader.
 /// Although consensus is leaderless, it is often necessary to have a single
 /// source of truth for the cluster management. The leader node can be used for this purpose.
+///
+/// Two modes of operation:
+/// 1. **Local election** (backward compatible): Leader is computed locally on view change
+///    and notifications are sent immediately via synchronous `router.route()`.
+/// 2. **Consensus-based election**: Leader proposal is submitted through consensus.
+///    Notifications are sent asynchronously via `router.routeAsync()` only after commit.
 public interface LeaderManager {
     /// Get the current leader node ID.
     /// @return the current leader, or empty if no leader is elected
@@ -41,10 +50,49 @@ public interface LeaderManager {
     /// Check if this node is the current leader.
     boolean isLeader();
 
+    /// Called when leader election is committed through consensus.
+    /// Updates local state and sends async notification.
+    ///
+    /// @param leader the committed leader node ID
+    /// @param viewSequence the view sequence number for consistency checking
+    void onLeaderCommitted(NodeId leader, long viewSequence);
+
+    /// Handler for submitting leader proposals through consensus.
+    /// When provided, leader election goes through consensus instead of local computation.
+    @FunctionalInterface
+    interface LeaderProposalHandler {
+        /// Submit a leader proposal through consensus.
+        ///
+        /// @param candidate the proposed leader node ID
+        /// @param viewSequence monotonic view sequence number
+        /// @return Promise that completes when proposal is submitted (not necessarily committed)
+        Promise<Unit> propose(NodeId candidate, long viewSequence);
+    }
+
+    /// Create a leader manager with local election (backward compatible).
+    /// Leader is computed locally on view change and notifications are sent immediately.
     static LeaderManager leaderManager(NodeId self, MessageRouter router) {
+        return leaderManager(self, router, Option.none());
+    }
+
+    /// Create a leader manager with consensus-based election.
+    /// When proposal handler is provided, leader election goes through consensus.
+    ///
+    /// @param self this node's ID
+    /// @param router message router for notifications
+    /// @param proposalHandler handler for submitting proposals through consensus
+    static LeaderManager leaderManager(NodeId self, MessageRouter router, LeaderProposalHandler proposalHandler) {
+        return leaderManager(self, router, Option.some(proposalHandler));
+    }
+
+    private static LeaderManager leaderManager(NodeId self,
+                                               MessageRouter router,
+                                               Option<LeaderProposalHandler> proposalHandler) {
         record leaderManager(NodeId self,
                              MessageRouter router,
+                             Option<LeaderProposalHandler> proposalHandler,
                              AtomicBoolean active,
+                             AtomicLong viewSequence,
                              AtomicReference<Option<NodeId>> currentLeader) implements LeaderManager {
             @Override
             public Option<NodeId> leader() {
@@ -56,6 +104,22 @@ public interface LeaderManager {
                 return currentLeader.get()
                                     .filter(self::equals)
                                     .isPresent();
+            }
+
+            @Override
+            public void onLeaderCommitted(NodeId leader, long committedViewSequence) {
+                // Reject stale proposals
+                if (committedViewSequence < viewSequence.get()) {
+                    return;
+                }
+                var oldLeader = currentLeader.get();
+                var newLeader = Option.some(leader);
+                if (currentLeader.compareAndSet(oldLeader, newLeader)) {
+                    viewSequence.set(committedViewSequence);
+                    if (!newLeader.equals(oldLeader)) {
+                        notifyLeaderChangeAsync();
+                    }
+                }
             }
 
             @Override
@@ -77,15 +141,36 @@ public interface LeaderManager {
 
             @Override
             public void nodeDown(NodeDown nodeDown) {
-                currentLeader().set(Option.none());
+                currentLeader.set(Option.none());
                 stop();
             }
 
             private void tryElect(NodeId candidate) {
-                var oldLeader = currentLeader().get();
+                if (!active.get()) {
+                    // Not active yet, just track the candidate locally
+                    var oldLeader = currentLeader.get();
+                    var newLeader = Option.some(candidate);
+                    currentLeader.compareAndSet(oldLeader, newLeader);
+                    return;
+                }
+                proposalHandler.fold(() -> {
+                                         // Local election mode: immediate update and sync notification
+                electLocally(candidate);
+                                         return Unit.unit();
+                                     },
+                                     handler -> {
+                                         // Consensus mode: submit proposal, notification on commit
+                var nextViewSequence = viewSequence.incrementAndGet();
+                                         handler.propose(candidate, nextViewSequence);
+                                         return Unit.unit();
+                                     });
+            }
+
+            private void electLocally(NodeId candidate) {
+                var oldLeader = currentLeader.get();
                 var newLeader = Option.some(candidate);
                 // Potential leader change. Implicitly handles initial election.
-                if (currentLeader().compareAndSet(oldLeader, newLeader)) {
+                if (currentLeader.compareAndSet(oldLeader, newLeader)) {
                     if (!newLeader.equals(oldLeader)) {
                         notifyLeaderChange();
                     }
@@ -93,11 +178,22 @@ public interface LeaderManager {
             }
 
             private void notifyLeaderChange() {
-                if (active().get()) {
-                    var leaderOpt = currentLeader().get();
-                    router().route(leaderChange(leaderOpt,
-                                                leaderOpt.filter(self::equals)
-                                                         .isPresent()));
+                if (active.get()) {
+                    var leaderOpt = currentLeader.get();
+                    router.route(leaderChange(leaderOpt,
+                                              leaderOpt.filter(self::equals)
+                                                       .isPresent()));
+                }
+            }
+
+            private void notifyLeaderChangeAsync() {
+                if (active.get()) {
+                    router.routeAsync(() -> {
+                                          var leaderOpt = currentLeader.get();
+                                          return leaderChange(leaderOpt,
+                                                              leaderOpt.filter(self::equals)
+                                                                       .isPresent());
+                                      });
                 }
             }
 
@@ -111,18 +207,37 @@ public interface LeaderManager {
 
             private void start() {
                 active.set(true);
-                notifyLeaderChange();
+                // In consensus mode, submit a proposal if there's a candidate
+                // Clear local state so first commit triggers notification
+                // In local mode, notify immediately
+                var candidate = currentLeader.get();
+                candidate.onPresent(leader -> proposalHandler.fold(() -> {
+                                                                       notifyLeaderChange();
+                                                                       return Unit.unit();
+                                                                   },
+                                                                   handler -> {
+                                                                       // Clear local state in consensus mode - notification comes from commit
+                currentLeader.set(Option.none());
+                                                                       var nextViewSequence = viewSequence.incrementAndGet();
+                                                                       handler.propose(leader, nextViewSequence);
+                                                                       return Unit.unit();
+                                                                   }));
             }
 
             private void stop() {
                 // Set inactive first to prevent new elections during shutdown
                 active.set(false);
-                currentLeader().set(Option.none());
-                // Send notification directly since active is now false
-                router().route(leaderChange(Option.none(), false));
+                currentLeader.set(Option.none());
+                // Always send stop notification synchronously for immediate effect
+                router.route(leaderChange(Option.none(), false));
             }
         }
-        return new leaderManager(self, router, new AtomicBoolean(false), new AtomicReference<>(Option.none()));
+        return new leaderManager(self,
+                                 router,
+                                 proposalHandler,
+                                 new AtomicBoolean(false),
+                                 new AtomicLong(0),
+                                 new AtomicReference<>(Option.none()));
     }
 
     @MessageReceiver

--- a/integrations/db/jdbc/README.md
+++ b/integrations/db/jdbc/README.md
@@ -8,7 +8,7 @@ Promise-based JDBC operations with typed error handling.
 <dependency>
     <groupId>org.pragmatica-lite</groupId>
     <artifactId>jdbc</artifactId>
-    <version>0.11.1</version>
+    <version>0.11.2</version>
 </dependency>
 ```
 

--- a/integrations/db/jdbc/pom.xml
+++ b/integrations/db/jdbc/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>db</artifactId>
         <groupId>org.pragmatica-lite</groupId>
-        <version>0.11.1</version>
+        <version>0.11.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integrations/db/jooq-r2dbc/README.md
+++ b/integrations/db/jooq-r2dbc/README.md
@@ -8,7 +8,7 @@ Promise-based JOOQ with R2DBC for type-safe reactive database access.
 <dependency>
     <groupId>org.pragmatica-lite</groupId>
     <artifactId>jooq-r2dbc</artifactId>
-    <version>0.11.1</version>
+    <version>0.11.2</version>
 </dependency>
 ```
 

--- a/integrations/db/jooq-r2dbc/pom.xml
+++ b/integrations/db/jooq-r2dbc/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>db</artifactId>
         <groupId>org.pragmatica-lite</groupId>
-        <version>0.11.1</version>
+        <version>0.11.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integrations/db/jooq/pom.xml
+++ b/integrations/db/jooq/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>db</artifactId>
         <groupId>org.pragmatica-lite</groupId>
-        <version>0.11.1</version>
+        <version>0.11.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integrations/db/jpa/README.md
+++ b/integrations/db/jpa/README.md
@@ -8,7 +8,7 @@ Promise-based JPA EntityManager wrapper with typed error handling.
 <dependency>
     <groupId>org.pragmatica-lite</groupId>
     <artifactId>jpa</artifactId>
-    <version>0.11.1</version>
+    <version>0.11.2</version>
 </dependency>
 ```
 

--- a/integrations/db/jpa/pom.xml
+++ b/integrations/db/jpa/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>db</artifactId>
         <groupId>org.pragmatica-lite</groupId>
-        <version>0.11.1</version>
+        <version>0.11.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integrations/db/pom.xml
+++ b/integrations/db/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>integrations</artifactId>
         <groupId>org.pragmatica-lite</groupId>
-        <version>0.11.1</version>
+        <version>0.11.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integrations/db/r2dbc/README.md
+++ b/integrations/db/r2dbc/README.md
@@ -8,7 +8,7 @@ Promise-based reactive database access with typed error handling.
 <dependency>
     <groupId>org.pragmatica-lite</groupId>
     <artifactId>r2dbc</artifactId>
-    <version>0.11.1</version>
+    <version>0.11.2</version>
 </dependency>
 ```
 

--- a/integrations/db/r2dbc/pom.xml
+++ b/integrations/db/r2dbc/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>db</artifactId>
         <groupId>org.pragmatica-lite</groupId>
-        <version>0.11.1</version>
+        <version>0.11.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integrations/dht/pom.xml
+++ b/integrations/dht/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>integrations</artifactId>
         <groupId>org.pragmatica-lite</groupId>
-        <version>0.11.1</version>
+        <version>0.11.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integrations/http-routing/pom.xml
+++ b/integrations/http-routing/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.pragmatica-lite</groupId>
         <artifactId>integrations</artifactId>
-        <version>0.11.1</version>
+        <version>0.11.2</version>
     </parent>
 
     <artifactId>http-routing</artifactId>

--- a/integrations/http-routing/src/main/java/org/pragmatica/http/routing/PathParameter.java
+++ b/integrations/http-routing/src/main/java/org/pragmatica/http/routing/PathParameter.java
@@ -125,14 +125,23 @@ public interface PathParameter<T> {
      * Accepts "true"/"false" and "yes"/"no" (case-insensitive).
      */
     static PathParameter<Boolean> aBoolean() {
-        return value -> {
-            if (value.equalsIgnoreCase("true") || value.equalsIgnoreCase("yes")) {
-                return Result.success(true);
-            } else if (value.equalsIgnoreCase("false") || value.equalsIgnoreCase("no")) {
-                return Result.success(false);
-            }
-            return new InvalidParameter("Invalid boolean value: " + value + " (expected true/false or yes/no)").result();
-        };
+        return PathParameter::parseBooleanValue;
+    }
+
+    private static Result<Boolean> parseBooleanValue(String value) {
+        return isTrueValue(value)
+               ? Result.success(true)
+               : isFalseValue(value)
+                 ? Result.success(false)
+                 : new InvalidParameter("Invalid boolean value: " + value + " (expected true/false or yes/no)").result();
+    }
+
+    private static boolean isTrueValue(String value) {
+        return value.equalsIgnoreCase("true") || value.equalsIgnoreCase("yes");
+    }
+
+    private static boolean isFalseValue(String value) {
+        return value.equalsIgnoreCase("false") || value.equalsIgnoreCase("no");
     }
 
     /**

--- a/integrations/http-routing/src/main/java/org/pragmatica/http/routing/PathParameter.java
+++ b/integrations/http-routing/src/main/java/org/pragmatica/http/routing/PathParameter.java
@@ -34,14 +34,27 @@ public interface PathParameter<T> {
     /**
      * Creates a spacer that matches a literal path segment.
      * Used for fixed path components like "/api" or "/users".
+     * <p>
+     * Spacers extend the route's registered path, allowing multiple routes
+     * with different trailing spacers to coexist (e.g., /api/foo/{id}/edit vs /api/foo/{id}/delete).
      *
      * @param text the expected literal value
      * @return parser that succeeds only if value matches exactly
      */
     static PathParameter<String> spacer(String text) {
-        return value -> text.equals(value)
-                        ? Result.success(value)
-                        : new PathMismatch(text, value).result();
+        return new Spacer(text);
+    }
+
+    /**
+     * Spacer implementation that tracks the literal text for path registration.
+     */
+    record Spacer(String text) implements PathParameter<String> {
+        @Override
+        public Result<String> parse(String value) {
+            return text.equals(value)
+                   ? Result.success(value)
+                   : new PathMismatch(text, value).result();
+        }
     }
 
     /**

--- a/integrations/http-routing/src/main/java/org/pragmatica/http/routing/RequestContext.java
+++ b/integrations/http-routing/src/main/java/org/pragmatica/http/routing/RequestContext.java
@@ -20,6 +20,7 @@ public interface RequestContext {
     Result<String> NOT_FOUND = HttpStatus.NOT_FOUND.with("Unknown request path")
                                         .result();
     Route<?> route();
+    String requestPath();
     String requestId();
     ByteBuf body();
     String bodyAsString();

--- a/integrations/http-routing/src/main/java/org/pragmatica/http/routing/RequestContextImpl.java
+++ b/integrations/http-routing/src/main/java/org/pragmatica/http/routing/RequestContextImpl.java
@@ -57,6 +57,11 @@ public final class RequestContextImpl implements RequestContext {
     }
 
     @Override
+    public String requestPath() {
+        return PathUtils.normalize(request.uri());
+    }
+
+    @Override
     public String requestId() {
         return requestId;
     }

--- a/integrations/http-routing/src/main/java/org/pragmatica/http/routing/RequestContextImpl.java
+++ b/integrations/http-routing/src/main/java/org/pragmatica/http/routing/RequestContextImpl.java
@@ -97,12 +97,23 @@ public final class RequestContextImpl implements RequestContext {
     }
 
     private List<String> initPathParams() {
-        var elements = PathUtils.normalize(request.uri())
-                                .substring(route.path()
-                                                .length())
-                                .split("/", PATH_PARAM_LIMIT);
-        return List.of(elements)
-                   .subList(0, elements.length - 1);
+        var remainder = PathUtils.normalize(request.uri())
+                                 .substring(route.path()
+                                                 .length());
+        // Strip leading slash before splitting
+        if (remainder.startsWith("/")) {
+            remainder = remainder.substring(1);
+        }
+        if (remainder.isEmpty()) {
+            return List.of();
+        }
+        var elements = remainder.split("/", PATH_PARAM_LIMIT);
+        // Remove trailing empty element if path ends with /
+        if (elements[elements.length - 1].isEmpty()) {
+            return List.of(elements)
+                       .subList(0, elements.length - 1);
+        }
+        return List.of(elements);
     }
 
     private Map<String, List<String>> initQueryParams() {

--- a/integrations/http-routing/src/main/java/org/pragmatica/http/routing/RequestRouter.java
+++ b/integrations/http-routing/src/main/java/org/pragmatica/http/routing/RequestRouter.java
@@ -2,7 +2,9 @@ package org.pragmatica.http.routing;
 
 import org.pragmatica.lang.Option;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.stream.Stream;
@@ -15,9 +17,10 @@ import static org.pragmatica.lang.Option.option;
 public final class RequestRouter {
     private static final Logger log = LoggerFactory.getLogger(RequestRouter.class);
 
-    private final Map<HttpMethod, TreeMap<String, Route<?>>> routes;
+    // Store multiple routes per base path to handle routes with different spacers
+    private final Map<HttpMethod, TreeMap<String, List<Route<?>>>> routes;
 
-    private RequestRouter(Map<HttpMethod, TreeMap<String, Route<?>>> routes) {
+    private RequestRouter(Map<HttpMethod, TreeMap<String, List<Route<?>>>> routes) {
         this.routes = routes;
     }
 
@@ -26,16 +29,19 @@ public final class RequestRouter {
     }
 
     public static RequestRouter with(Stream<RouteSource> routeStream) {
-        var routes = new HashMap<HttpMethod, TreeMap<String, Route<?>>>();
+        var routes = new HashMap<HttpMethod, TreeMap<String, List<Route<?>>>>();
         routeStream.flatMap(RouteSource::routes)
                    .forEach(route -> routes.compute(route.method(),
                                                     (_, pathMap) -> collectRoutes(route, pathMap)));
         return new RequestRouter(routes);
     }
 
-    private static TreeMap<String, Route<?>> collectRoutes(Route<?> route, TreeMap<String, Route<?>> pathMap) {
+    private static TreeMap<String, List<Route<?>>> collectRoutes(Route<?> route,
+                                                                 TreeMap<String, List<Route<?>>> pathMap) {
         var map = option(pathMap).or(TreeMap::new);
-        map.put(route.path(), route);
+        map.computeIfAbsent(route.path(),
+                            _ -> new ArrayList<>())
+           .add(route);
         return map;
     }
 
@@ -43,7 +49,8 @@ public final class RequestRouter {
         if (!log.isInfoEnabled()) {
             return;
         }
-        routes.forEach((_, endpoints) -> endpoints.forEach((_, route) -> log.info("{}", route)));
+        routes.forEach((_, endpoints) -> endpoints.forEach((_, routeList) -> routeList.forEach(route -> log.info("{}",
+                                                                                                                 route))));
     }
 
     public Option<Route<?>> findRoute(HttpMethod method, String inputPath) {
@@ -51,7 +58,64 @@ public final class RequestRouter {
         return option(routes.get(method)).flatMap(map -> option(map.floorEntry(path)))
                      .filter(routeEntry -> isSameOrStartOfPath(path,
                                                                routeEntry.getKey()))
-                     .map(Map.Entry::getValue);
+                     .flatMap(routeEntry -> selectBestRoute(routeEntry.getValue(),
+                                                            inputPath));
+    }
+
+    /**
+     * Select the best matching route from a list of routes with the same base path.
+     * This handles routes that differ only in their spacer parameters.
+     */
+    private Option<Route<?>> selectBestRoute(List<Route<?>> candidates, String inputPath) {
+        if (candidates.size() == 1) {
+            return Option.some(candidates.getFirst());
+        }
+        // Multiple routes - find the one whose spacers match the input path
+        // First try routes with spacers (more specific), then fallback to routes without spacers
+        Route<?> fallback = null;
+        for (var route : candidates) {
+            if (route.spacers()
+                     .isEmpty()) {
+                fallback = route;
+            } else if (routeMatchesPath(route, inputPath)) {
+                return Option.some(route);
+            }
+        }
+        // No spacer match - return fallback (route without spacers) or first candidate
+        return Option.some(fallback != null
+                           ? fallback
+                           : candidates.getFirst());
+    }
+
+    /**
+     * Check if a route matches the input path by verifying all spacers are present.
+     */
+    private boolean routeMatchesPath(Route<?> route, String inputPath) {
+        // Extract path elements after the route's base path
+        var basePath = route.path();
+        if (inputPath.length() <= basePath.length()) {
+            return route.spacers()
+                        .isEmpty();
+        }
+        var remainder = inputPath.substring(basePath.length());
+        if (remainder.startsWith("/")) {
+            remainder = remainder.substring(1);
+        }
+        var pathElements = remainder.split("/");
+        // Check if all spacers are present in the path elements
+        for (var spacer : route.spacers()) {
+            boolean found = false;
+            for (var element : pathElements) {
+                if (element.equals(spacer)) {
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private boolean isSameOrStartOfPath(String inputPath, String routePath) {

--- a/integrations/http-routing/src/main/java/org/pragmatica/http/routing/RequestRouter.java
+++ b/integrations/http-routing/src/main/java/org/pragmatica/http/routing/RequestRouter.java
@@ -131,6 +131,6 @@ public final class RequestRouter {
     }
 
     private static boolean isPrefixMatch(String inputPath, String routePath) {
-        return inputPath.length() > routePath.length() && inputPath.charAt(routePath.length() - 1) == '/';
+        return inputPath.length() > routePath.length() && inputPath.startsWith(routePath) && inputPath.charAt(routePath.length() - 1) == '/';
     }
 }

--- a/integrations/http-routing/src/main/java/org/pragmatica/http/routing/Route.java
+++ b/integrations/http-routing/src/main/java/org/pragmatica/http/routing/Route.java
@@ -6,6 +6,8 @@ import org.pragmatica.lang.Promise;
 import org.pragmatica.lang.Result;
 import org.pragmatica.lang.type.TypeToken;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
@@ -59,6 +61,15 @@ public interface Route<T> extends RouteSource {
 
     ContentType contentType();
 
+    /**
+     * Returns the spacer patterns for this route.
+     * Spacers are literal path segments that must appear in the URL.
+     * Used for distinguishing routes with the same base path but different trailing segments.
+     */
+    default List<String> spacers() {
+        return List.of();
+    }
+
     @Override
     default Stream<Route<?>> routes() {
         return Stream.of(this);
@@ -68,18 +79,33 @@ public interface Route<T> extends RouteSource {
     RouteSource withPrefix(String prefix);
 
     static <T> Route<T> route(HttpMethod method, String path, Handler<T> handler, ContentType contentType) {
-        record route<T>(HttpMethod method, String path, Handler<T> handler, ContentType contentType) implements Route<T> {
+        return route(method, path, handler, contentType, List.of());
+    }
+
+    static <T> Route<T> route(HttpMethod method,
+                              String path,
+                              Handler<T> handler,
+                              ContentType contentType,
+                              List<String> spacers) {
+        record route<T>(HttpMethod method,
+                        String path,
+                        Handler<T> handler,
+                        ContentType contentType,
+                        List<String> spacers) implements Route<T> {
             @Override
             public RouteSource withPrefix(String prefix) {
-                return new route<>(method, PathUtils.normalize(prefix + path), handler, contentType);
+                return new route<>(method, PathUtils.normalize(prefix + path), handler, contentType, spacers);
             }
 
             @Override
             public String toString() {
-                return "Route: " + method + " " + path + ", " + contentType;
+                var spacerStr = spacers.isEmpty()
+                                ? ""
+                                : " [spacers: " + String.join(", ", spacers) + "]";
+                return "Route: " + method + " " + path + spacerStr + ", " + contentType;
             }
         }
-        return new route<>(method, PathUtils.normalize(path), handler, contentType);
+        return new route<>(method, PathUtils.normalize(path), handler, contentType, spacers);
     }
 
     static Subroutes in(String path) {
@@ -761,28 +787,35 @@ public interface Route<T> extends RouteSource {
     // ===================================================================================
     // Implementation
     // ===================================================================================
-    record ParameterBuilderImpl<R>(HttpMethod method, String path) implements ParameterBuilder<R> {
-        @Override
-        public ContentTypeBuilder<R> to(Handler<R> handler) {
-            return contentType -> route(method, path, handler, contentType);
+    record ParameterBuilderImpl<R>(HttpMethod method, String path, List<String> spacers) implements ParameterBuilder<R> {
+        ParameterBuilderImpl(HttpMethod method, String path) {
+            this(method, path, List.of());
         }
 
-        // Path parameters
+        @Override
+        public ContentTypeBuilder<R> to(Handler<R> handler) {
+            return contentType -> route(method, path, handler, contentType, spacers);
+        }
+
+        // Path parameters - collect spacers from path parameter definitions
         @Override
         public <P1> PathBuilder1<R, P1> withPath(PathParameter<P1> p1) {
-            return new PathBuilder1Impl<>(this, p1);
+            var collected = collectSpacers(p1);
+            return new PathBuilder1Impl<>(new ParameterBuilderImpl<>(method, path, collected), p1);
         }
 
         @Override
         public <P1, P2> PathBuilder2<R, P1, P2> withPath(PathParameter<P1> p1, PathParameter<P2> p2) {
-            return new PathBuilder2Impl<>(this, p1, p2);
+            var collected = collectSpacers(p1, p2);
+            return new PathBuilder2Impl<>(new ParameterBuilderImpl<>(method, path, collected), p1, p2);
         }
 
         @Override
         public <P1, P2, P3> PathBuilder3<R, P1, P2, P3> withPath(PathParameter<P1> p1,
                                                                  PathParameter<P2> p2,
                                                                  PathParameter<P3> p3) {
-            return new PathBuilder3Impl<>(this, p1, p2, p3);
+            var collected = collectSpacers(p1, p2, p3);
+            return new PathBuilder3Impl<>(new ParameterBuilderImpl<>(method, path, collected), p1, p2, p3);
         }
 
         @Override
@@ -790,7 +823,8 @@ public interface Route<T> extends RouteSource {
                                                                          PathParameter<P2> p2,
                                                                          PathParameter<P3> p3,
                                                                          PathParameter<P4> p4) {
-            return new PathBuilder4Impl<>(this, p1, p2, p3, p4);
+            var collected = collectSpacers(p1, p2, p3, p4);
+            return new PathBuilder4Impl<>(new ParameterBuilderImpl<>(method, path, collected), p1, p2, p3, p4);
         }
 
         @Override
@@ -799,7 +833,20 @@ public interface Route<T> extends RouteSource {
                                                                                  PathParameter<P3> p3,
                                                                                  PathParameter<P4> p4,
                                                                                  PathParameter<P5> p5) {
-            return new PathBuilder5Impl<>(this, p1, p2, p3, p4, p5);
+            var collected = collectSpacers(p1, p2, p3, p4, p5);
+            return new PathBuilder5Impl<>(new ParameterBuilderImpl<>(method, path, collected), p1, p2, p3, p4, p5);
+        }
+
+        // Helper to collect spacer text from path parameters
+        @SafeVarargs
+        private static List<String> collectSpacers(PathParameter<?>... params) {
+            var spacers = new ArrayList<String>();
+            for (var param : params) {
+                if (param instanceof PathParameter.Spacer s) {
+                    spacers.add(s.text());
+                }
+            }
+            return List.copyOf(spacers);
         }
 
         // Body only

--- a/integrations/http-routing/src/main/java/org/pragmatica/http/routing/Route.java
+++ b/integrations/http-routing/src/main/java/org/pragmatica/http/routing/Route.java
@@ -86,6 +86,17 @@ public interface Route<T> extends RouteSource {
         return () -> path;
     }
 
+    /**
+     * Creates a route source for serving static files from the classpath.
+     *
+     * @param urlPrefix       the URL prefix to match (e.g., "/static")
+     * @param classpathPrefix the classpath prefix where files are located (e.g., "/web")
+     * @return a route source that serves static files
+     */
+    static RouteSource staticFiles(String urlPrefix, String classpathPrefix) {
+        return StaticFileRouteSource.staticFiles(urlPrefix, classpathPrefix);
+    }
+
     interface Subroutes {
         String path();
 

--- a/integrations/http-routing/src/main/java/org/pragmatica/http/routing/StaticFileRouteSource.java
+++ b/integrations/http-routing/src/main/java/org/pragmatica/http/routing/StaticFileRouteSource.java
@@ -1,0 +1,186 @@
+package org.pragmatica.http.routing;
+
+import org.pragmatica.lang.Cause;
+import org.pragmatica.lang.Promise;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static org.pragmatica.http.routing.ContentCategory.BINARY;
+import static org.pragmatica.http.routing.ContentCategory.HTML;
+import static org.pragmatica.http.routing.ContentCategory.JSON;
+import static org.pragmatica.http.routing.ContentCategory.PLAIN_TEXT;
+import static org.pragmatica.http.routing.ContentType.contentType;
+import static org.pragmatica.http.routing.HttpMethod.GET;
+import static org.pragmatica.http.routing.Route.route;
+
+/**
+ * Route source for serving static files from the classpath.
+ * <p>
+ * Supports common web content types and provides security against directory traversal attacks.
+ * <p>
+ * Example usage:
+ * <pre>{@code
+ * var routes = StaticFileRouteSource.staticFiles("/static", "/web");
+ * // Serves /static/app.js from classpath:/web/app.js
+ * }</pre>
+ */
+public interface StaticFileRouteSource extends RouteSource {
+    Map<String, ContentType> CONTENT_TYPES = Map.ofEntries(Map.entry(".html",
+                                                                     contentType("text/html; charset=UTF-8", HTML)),
+                                                           Map.entry(".htm",
+                                                                     contentType("text/html; charset=UTF-8", HTML)),
+                                                           Map.entry(".css",
+                                                                     contentType("text/css; charset=UTF-8", PLAIN_TEXT)),
+                                                           Map.entry(".js",
+                                                                     contentType("text/javascript; charset=UTF-8",
+                                                                                 PLAIN_TEXT)),
+                                                           Map.entry(".json",
+                                                                     contentType("application/json; charset=UTF-8", JSON)),
+                                                           Map.entry(".png", contentType("image/png", BINARY)),
+                                                           Map.entry(".jpg", contentType("image/jpeg", BINARY)),
+                                                           Map.entry(".jpeg", contentType("image/jpeg", BINARY)),
+                                                           Map.entry(".gif", contentType("image/gif", BINARY)),
+                                                           Map.entry(".svg", contentType("image/svg+xml", BINARY)),
+                                                           Map.entry(".ico", contentType("image/x-icon", BINARY)),
+                                                           Map.entry(".woff", contentType("font/woff", BINARY)),
+                                                           Map.entry(".woff2", contentType("font/woff2", BINARY)),
+                                                           Map.entry(".ttf", contentType("font/ttf", BINARY)),
+                                                           Map.entry(".eot",
+                                                                     contentType("application/vnd.ms-fontobject", BINARY)),
+                                                           Map.entry(".xml",
+                                                                     contentType("application/xml; charset=UTF-8",
+                                                                                 PLAIN_TEXT)),
+                                                           Map.entry(".txt",
+                                                                     contentType("text/plain; charset=UTF-8", PLAIN_TEXT)),
+                                                           Map.entry(".map",
+                                                                     contentType("application/json; charset=UTF-8", JSON)));
+
+    ContentType DEFAULT_CONTENT_TYPE = CommonContentTypes.APPLICATION_OCTET_STREAM;
+
+    /**
+     * Creates a route source for serving static files from the classpath.
+     *
+     * @param urlPrefix       the URL prefix to match (e.g., "/static")
+     * @param classpathPrefix the classpath prefix where files are located (e.g., "/web")
+     * @return a route source that serves static files
+     */
+    static StaticFileRouteSource staticFiles(String urlPrefix, String classpathPrefix) {
+        var normalizedUrlPrefix = PathUtils.normalize(urlPrefix);
+        var normalizedClasspathPrefix = normalizeClasspathPrefix(classpathPrefix);
+        return () -> Stream.of(route(GET,
+                                     normalizedUrlPrefix,
+                                     createHandler(normalizedUrlPrefix, normalizedClasspathPrefix),
+                                     DEFAULT_CONTENT_TYPE));
+    }
+
+    private static String normalizeClasspathPrefix(String prefix) {
+        var result = prefix.startsWith("/")
+                     ? prefix
+                     : "/" + prefix;
+        return result.endsWith("/")
+               ? result.substring(0, result.length() - 1)
+               : result;
+    }
+
+    private static Handler<byte[]> createHandler(String urlPrefix, String classpathPrefix) {
+        return ctx -> {
+            var requestPath = ctx.route()
+                                 .path();
+            var relativePath = extractRelativePath(requestPath, urlPrefix);
+            return validatePath(relativePath)
+            .fold(cause -> cause.promise(), validPath -> loadResource(classpathPrefix, validPath, ctx));
+        };
+    }
+
+    private static String extractRelativePath(String requestPath, String urlPrefix) {
+        var path = requestPath.startsWith(urlPrefix)
+                   ? requestPath.substring(urlPrefix.length())
+                   : requestPath;
+        return path.isEmpty()
+               ? "/"
+               : path;
+    }
+
+    private static org.pragmatica.lang.Result<String> validatePath(String path) {
+        if (path.contains("..")) {
+            return StaticFileError.DIRECTORY_TRAVERSAL.result();
+        }
+        return org.pragmatica.lang.Result.success(path);
+    }
+
+    private static Promise<byte[]> loadResource(String classpathPrefix, String relativePath, RequestContext ctx) {
+        var resourcePath = resolveResourcePath(classpathPrefix, relativePath);
+        var contentType = detectContentType(resourcePath);
+        ctx.responseHeaders()
+           .set("Content-Type",
+                contentType.headerText());
+        ctx.responseHeaders()
+           .set("Cache-Control", "no-cache");
+        return Promise.lift(StaticFileError.ReadFailed::new, () -> readResource(resourcePath));
+    }
+
+    private static String resolveResourcePath(String classpathPrefix, String relativePath) {
+        var path = relativePath.endsWith("/")
+                   ? relativePath + "index.html"
+                   : relativePath;
+        return classpathPrefix + (path.startsWith("/")
+                                  ? path
+                                  : "/" + path);
+    }
+
+    private static byte[] readResource(String resourcePath) throws IOException {
+        try (InputStream is = StaticFileRouteSource.class.getResourceAsStream(resourcePath)) {
+            if (is == null) {
+                throw new IOException("Resource not found: " + resourcePath);
+            }
+            return is.readAllBytes();
+        }
+    }
+
+    static ContentType detectContentType(String path) {
+        var lastDot = path.lastIndexOf('.');
+        if (lastDot < 0) {
+            return DEFAULT_CONTENT_TYPE;
+        }
+        var extension = path.substring(lastDot)
+                            .toLowerCase();
+        return CONTENT_TYPES.getOrDefault(extension, DEFAULT_CONTENT_TYPE);
+    }
+
+    /**
+     * Errors that can occur when serving static files.
+     */
+    sealed interface StaticFileError extends Cause {
+        enum General implements StaticFileError {
+            DIRECTORY_TRAVERSAL("Directory traversal not allowed"),
+            NOT_FOUND("Resource not found");
+            private final String message;
+            General(String message) {
+                this.message = message;
+            }
+            @Override
+            public String message() {
+                return message;
+            }
+        }
+
+        StaticFileError DIRECTORY_TRAVERSAL = General.DIRECTORY_TRAVERSAL;
+
+        record ReadFailed(Throwable cause) implements StaticFileError {
+            @Override
+            public String message() {
+                return "Failed to read static file: " + cause.getMessage();
+            }
+        }
+    }
+
+    record unused() implements StaticFileRouteSource {
+        @Override
+        public Stream<Route<?>> routes() {
+            return Stream.empty();
+        }
+    }
+}

--- a/integrations/http-routing/src/test/java/org/pragmatica/http/routing/RequestContextQueryTest.java
+++ b/integrations/http-routing/src/test/java/org/pragmatica/http/routing/RequestContextQueryTest.java
@@ -35,6 +35,11 @@ class RequestContextQueryTest {
         }
 
         @Override
+        public String requestPath() {
+            return "/test/";
+        }
+
+        @Override
         public String requestId() {
             return "test-request-id";
         }

--- a/integrations/http-routing/src/test/java/org/pragmatica/http/routing/SpacerRouteTest.java
+++ b/integrations/http-routing/src/test/java/org/pragmatica/http/routing/SpacerRouteTest.java
@@ -1,0 +1,218 @@
+package org.pragmatica.http.routing;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.pragmatica.lang.Promise;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.pragmatica.http.routing.HttpMethod.GET;
+import static org.pragmatica.http.routing.PathParameter.aLong;
+import static org.pragmatica.http.routing.PathParameter.spacer;
+import static org.pragmatica.http.routing.Route.get;
+
+class SpacerRouteTest {
+
+    record TestResponse(String result) {}
+
+    @Nested
+    class SpacerParsing {
+        @Test
+        void spacer_succeeds_forExactMatch() {
+            var spacerParam = spacer("edit");
+
+            spacerParam.parse("edit")
+                       .onFailure(_ -> org.junit.jupiter.api.Assertions.fail())
+                       .onSuccess(value -> assertThat(value).isEqualTo("edit"));
+        }
+
+        @Test
+        void spacer_fails_forMismatch() {
+            var spacerParam = spacer("edit");
+
+            spacerParam.parse("delete")
+                       .onSuccess(_ -> org.junit.jupiter.api.Assertions.fail())
+                       .onFailure(cause -> {
+                           assertThat(cause).isInstanceOf(ParameterError.PathMismatch.class);
+                           assertThat(cause.message()).contains("edit").contains("delete");
+                       });
+        }
+
+        @Test
+        void spacer_fails_forEmptyValue() {
+            var spacerParam = spacer("edit");
+
+            spacerParam.parse("")
+                       .onSuccess(_ -> org.junit.jupiter.api.Assertions.fail());
+        }
+
+        @Test
+        void spacer_recordContainsText() {
+            var spacerParam = spacer("details");
+
+            assertThat(spacerParam).isInstanceOf(PathParameter.Spacer.class);
+            assertThat(((PathParameter.Spacer) spacerParam).text()).isEqualTo("details");
+        }
+    }
+
+    @Nested
+    class RouteSpacersCollection {
+        @Test
+        void route_withSpacer_hasSingleSpacerInList() {
+            Route<TestResponse> route = Route.<TestResponse>get("/api/users/")
+                .withPath(aLong(), spacer("edit"))
+                .to((id, _) -> Promise.success(new TestResponse("Edit user " + id)))
+                .asJson();
+
+            assertThat(route.spacers()).containsExactly("edit");
+        }
+
+        @Test
+        void route_withMultipleSpacers_hasAllSpacersInList() {
+            Route<TestResponse> route = Route.<TestResponse>get("/api/")
+                .withPath(spacer("users"), aLong(), spacer("profile"))
+                .to((_, id, _) -> Promise.success(new TestResponse("Profile " + id)))
+                .asJson();
+
+            assertThat(route.spacers()).containsExactly("users", "profile");
+        }
+
+        @Test
+        void route_withoutSpacers_hasEmptySpacersList() {
+            Route<TestResponse> route = Route.<TestResponse>get("/api/users/")
+                .withPath(aLong())
+                .to(id -> Promise.success(new TestResponse("User " + id)))
+                .asJson();
+
+            assertThat(route.spacers()).isEmpty();
+        }
+
+        @Test
+        void route_withNoPathParams_hasEmptySpacersList() {
+            Route<TestResponse> route = Route.<TestResponse>get("/api/health")
+                .to(_ -> Promise.success(new TestResponse("OK")))
+                .asJson();
+
+            assertThat(route.spacers()).isEmpty();
+        }
+
+        @Test
+        void route_toString_includesSpacers() {
+            Route<TestResponse> route = Route.<TestResponse>get("/api/users/")
+                .withPath(aLong(), spacer("edit"))
+                .to((id, _) -> Promise.success(new TestResponse("Edit " + id)))
+                .asJson();
+
+            assertThat(route.toString()).contains("edit");
+        }
+    }
+
+    @Nested
+    class RequestRouterSpacerSelection {
+        @Test
+        void router_findsRouteByMatchingSpacer() {
+            Route<TestResponse> editRoute = Route.<TestResponse>get("/api/users/")
+                .withPath(aLong(), spacer("edit"))
+                .to((id, _) -> Promise.success(new TestResponse("Edit " + id)))
+                .asJson();
+
+            Route<TestResponse> deleteRoute = Route.<TestResponse>get("/api/users/")
+                .withPath(aLong(), spacer("delete"))
+                .to((id, _) -> Promise.success(new TestResponse("Delete " + id)))
+                .asJson();
+
+            var router = RequestRouter.with(editRoute, deleteRoute);
+
+            router.findRoute(GET, "/api/users/123/edit")
+                  .onEmpty(org.junit.jupiter.api.Assertions::fail)
+                  .onPresent(route -> assertThat(route.spacers()).containsExactly("edit"));
+
+            router.findRoute(GET, "/api/users/456/delete")
+                  .onEmpty(org.junit.jupiter.api.Assertions::fail)
+                  .onPresent(route -> assertThat(route.spacers()).containsExactly("delete"));
+        }
+
+        @Test
+        void router_fallbackToRouteWithoutSpacers() {
+            Route<TestResponse> editRoute = Route.<TestResponse>get("/api/users/")
+                .withPath(aLong(), spacer("edit"))
+                .to((id, _) -> Promise.success(new TestResponse("Edit " + id)))
+                .asJson();
+
+            Route<TestResponse> fallbackRoute = Route.<TestResponse>get("/api/users/")
+                .withPath(aLong())
+                .to(id -> Promise.success(new TestResponse("View " + id)))
+                .asJson();
+
+            var router = RequestRouter.with(editRoute, fallbackRoute);
+
+            // Request with edit spacer matches edit route
+            router.findRoute(GET, "/api/users/123/edit")
+                  .onEmpty(org.junit.jupiter.api.Assertions::fail)
+                  .onPresent(route -> assertThat(route.spacers()).containsExactly("edit"));
+
+            // Request without spacer falls back to generic route
+            router.findRoute(GET, "/api/users/123")
+                  .onEmpty(org.junit.jupiter.api.Assertions::fail)
+                  .onPresent(route -> assertThat(route.spacers()).isEmpty());
+        }
+
+        @Test
+        void router_singleRouteReturnsWithoutSpacerMatching() {
+            Route<TestResponse> route = Route.<TestResponse>get("/api/items/")
+                .withPath(aLong())
+                .to(id -> Promise.success(new TestResponse("Item " + id)))
+                .asJson();
+
+            var router = RequestRouter.with(route);
+
+            router.findRoute(GET, "/api/items/42")
+                  .onEmpty(org.junit.jupiter.api.Assertions::fail)
+                  .onPresent(found -> assertThat(found.path()).isEqualTo("/api/items/"));
+        }
+
+        @Test
+        void router_threeRoutesWithDifferentSpacers() {
+            Route<TestResponse> viewRoute = Route.<TestResponse>get("/api/orders/")
+                .withPath(aLong(), spacer("view"))
+                .to((id, _) -> Promise.success(new TestResponse("View " + id)))
+                .asJson();
+
+            Route<TestResponse> cancelRoute = Route.<TestResponse>get("/api/orders/")
+                .withPath(aLong(), spacer("cancel"))
+                .to((id, _) -> Promise.success(new TestResponse("Cancel " + id)))
+                .asJson();
+
+            Route<TestResponse> refundRoute = Route.<TestResponse>get("/api/orders/")
+                .withPath(aLong(), spacer("refund"))
+                .to((id, _) -> Promise.success(new TestResponse("Refund " + id)))
+                .asJson();
+
+            var router = RequestRouter.with(viewRoute, cancelRoute, refundRoute);
+
+            router.findRoute(GET, "/api/orders/1/view")
+                  .onEmpty(org.junit.jupiter.api.Assertions::fail)
+                  .onPresent(route -> assertThat(route.spacers()).containsExactly("view"));
+
+            router.findRoute(GET, "/api/orders/2/cancel")
+                  .onEmpty(org.junit.jupiter.api.Assertions::fail)
+                  .onPresent(route -> assertThat(route.spacers()).containsExactly("cancel"));
+
+            router.findRoute(GET, "/api/orders/3/refund")
+                  .onEmpty(org.junit.jupiter.api.Assertions::fail)
+                  .onPresent(route -> assertThat(route.spacers()).containsExactly("refund"));
+        }
+
+        @Test
+        void router_noMatchReturnsEmpty() {
+            Route<TestResponse> route = Route.<TestResponse>get("/api/users/")
+                .withPath(aLong())
+                .to(id -> Promise.success(new TestResponse("User " + id)))
+                .asJson();
+
+            var router = RequestRouter.with(route);
+
+            router.findRoute(GET, "/api/orders/123")
+                  .onPresent(_ -> org.junit.jupiter.api.Assertions.fail());
+        }
+    }
+}

--- a/integrations/http-routing/src/test/java/org/pragmatica/http/routing/StaticFileRouteSourceTest.java
+++ b/integrations/http-routing/src/test/java/org/pragmatica/http/routing/StaticFileRouteSourceTest.java
@@ -1,0 +1,268 @@
+package org.pragmatica.http.routing;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.pragmatica.http.routing.ContentCategory.BINARY;
+import static org.pragmatica.http.routing.ContentCategory.HTML;
+import static org.pragmatica.http.routing.ContentCategory.JSON;
+import static org.pragmatica.http.routing.ContentCategory.PLAIN_TEXT;
+import static org.pragmatica.http.routing.HttpMethod.GET;
+import static org.pragmatica.http.routing.StaticFileRouteSource.detectContentType;
+import static org.pragmatica.http.routing.StaticFileRouteSource.staticFiles;
+
+class StaticFileRouteSourceTest {
+
+    @Nested
+    class ContentTypeDetection {
+        @Test
+        void detectsHtmlContentType() {
+            var contentType = detectContentType("/index.html");
+            assertThat(contentType.headerText()).isEqualTo("text/html; charset=UTF-8");
+            assertThat(contentType.category()).isEqualTo(HTML);
+        }
+
+        @Test
+        void detectsHtmContentType() {
+            var contentType = detectContentType("/page.htm");
+            assertThat(contentType.headerText()).isEqualTo("text/html; charset=UTF-8");
+            assertThat(contentType.category()).isEqualTo(HTML);
+        }
+
+        @Test
+        void detectsCssContentType() {
+            var contentType = detectContentType("/styles/main.css");
+            assertThat(contentType.headerText()).isEqualTo("text/css; charset=UTF-8");
+            assertThat(contentType.category()).isEqualTo(PLAIN_TEXT);
+        }
+
+        @Test
+        void detectsJsContentType() {
+            var contentType = detectContentType("/scripts/app.js");
+            assertThat(contentType.headerText()).isEqualTo("text/javascript; charset=UTF-8");
+            assertThat(contentType.category()).isEqualTo(PLAIN_TEXT);
+        }
+
+        @Test
+        void detectsJsonContentType() {
+            var contentType = detectContentType("/data/config.json");
+            assertThat(contentType.headerText()).isEqualTo("application/json; charset=UTF-8");
+            assertThat(contentType.category()).isEqualTo(JSON);
+        }
+
+        @Test
+        void detectsPngContentType() {
+            var contentType = detectContentType("/images/logo.png");
+            assertThat(contentType.headerText()).isEqualTo("image/png");
+            assertThat(contentType.category()).isEqualTo(BINARY);
+        }
+
+        @Test
+        void detectsJpgContentType() {
+            var contentType = detectContentType("/images/photo.jpg");
+            assertThat(contentType.headerText()).isEqualTo("image/jpeg");
+            assertThat(contentType.category()).isEqualTo(BINARY);
+        }
+
+        @Test
+        void detectsJpegContentType() {
+            var contentType = detectContentType("/images/photo.jpeg");
+            assertThat(contentType.headerText()).isEqualTo("image/jpeg");
+            assertThat(contentType.category()).isEqualTo(BINARY);
+        }
+
+        @Test
+        void detectsGifContentType() {
+            var contentType = detectContentType("/images/animation.gif");
+            assertThat(contentType.headerText()).isEqualTo("image/gif");
+            assertThat(contentType.category()).isEqualTo(BINARY);
+        }
+
+        @Test
+        void detectsSvgContentType() {
+            var contentType = detectContentType("/icons/icon.svg");
+            assertThat(contentType.headerText()).isEqualTo("image/svg+xml");
+            assertThat(contentType.category()).isEqualTo(BINARY);
+        }
+
+        @Test
+        void detectsIcoContentType() {
+            var contentType = detectContentType("/favicon.ico");
+            assertThat(contentType.headerText()).isEqualTo("image/x-icon");
+            assertThat(contentType.category()).isEqualTo(BINARY);
+        }
+
+        @Test
+        void detectsWoffContentType() {
+            var contentType = detectContentType("/fonts/font.woff");
+            assertThat(contentType.headerText()).isEqualTo("font/woff");
+            assertThat(contentType.category()).isEqualTo(BINARY);
+        }
+
+        @Test
+        void detectsWoff2ContentType() {
+            var contentType = detectContentType("/fonts/font.woff2");
+            assertThat(contentType.headerText()).isEqualTo("font/woff2");
+            assertThat(contentType.category()).isEqualTo(BINARY);
+        }
+
+        @Test
+        void detectsTtfContentType() {
+            var contentType = detectContentType("/fonts/font.ttf");
+            assertThat(contentType.headerText()).isEqualTo("font/ttf");
+            assertThat(contentType.category()).isEqualTo(BINARY);
+        }
+
+        @Test
+        void detectsEotContentType() {
+            var contentType = detectContentType("/fonts/font.eot");
+            assertThat(contentType.headerText()).isEqualTo("application/vnd.ms-fontobject");
+            assertThat(contentType.category()).isEqualTo(BINARY);
+        }
+
+        @Test
+        void detectsXmlContentType() {
+            var contentType = detectContentType("/config.xml");
+            assertThat(contentType.headerText()).isEqualTo("application/xml; charset=UTF-8");
+            assertThat(contentType.category()).isEqualTo(PLAIN_TEXT);
+        }
+
+        @Test
+        void detectsTxtContentType() {
+            var contentType = detectContentType("/readme.txt");
+            assertThat(contentType.headerText()).isEqualTo("text/plain; charset=UTF-8");
+            assertThat(contentType.category()).isEqualTo(PLAIN_TEXT);
+        }
+
+        @Test
+        void detectsMapContentType() {
+            var contentType = detectContentType("/app.js.map");
+            assertThat(contentType.headerText()).isEqualTo("application/json; charset=UTF-8");
+            assertThat(contentType.category()).isEqualTo(JSON);
+        }
+
+        @Test
+        void returnsDefaultForUnknownExtension() {
+            var contentType = detectContentType("/file.xyz");
+            assertThat(contentType.headerText()).isEqualTo("application/octet-stream");
+            assertThat(contentType.category()).isEqualTo(BINARY);
+        }
+
+        @Test
+        void returnsDefaultForNoExtension() {
+            var contentType = detectContentType("/LICENSE");
+            assertThat(contentType.headerText()).isEqualTo("application/octet-stream");
+            assertThat(contentType.category()).isEqualTo(BINARY);
+        }
+
+        @Test
+        void handlesUpperCaseExtension() {
+            var contentType = detectContentType("/image.PNG");
+            assertThat(contentType.headerText()).isEqualTo("image/png");
+        }
+
+        @Test
+        void handlesMixedCaseExtension() {
+            var contentType = detectContentType("/script.Js");
+            assertThat(contentType.headerText()).isEqualTo("text/javascript; charset=UTF-8");
+        }
+    }
+
+    @Nested
+    class RouteCreation {
+        @Test
+        void createsRouteWithCorrectMethod() {
+            var routeSource = staticFiles("/static", "/web");
+            var routes = routeSource.routes().toList();
+
+            assertThat(routes).hasSize(1);
+            assertThat(routes.getFirst().method()).isEqualTo(GET);
+        }
+
+        @Test
+        void createsRouteWithNormalizedPath() {
+            var routeSource = staticFiles("/static", "/web");
+            var routes = routeSource.routes().toList();
+
+            assertThat(routes.getFirst().path()).isEqualTo("/static/");
+        }
+
+        @Test
+        void normalizesUrlPrefixWithoutLeadingSlash() {
+            var routeSource = staticFiles("static", "/web");
+            var routes = routeSource.routes().toList();
+
+            assertThat(routes.getFirst().path()).isEqualTo("/static/");
+        }
+
+        @Test
+        void normalizesUrlPrefixWithTrailingSlash() {
+            var routeSource = staticFiles("/static/", "/web");
+            var routes = routeSource.routes().toList();
+
+            assertThat(routes.getFirst().path()).isEqualTo("/static/");
+        }
+
+        @Test
+        void createsRouteWithHandler() {
+            var routeSource = staticFiles("/static", "/web");
+            var routes = routeSource.routes().toList();
+
+            assertThat(routes.getFirst().handler()).isNotNull();
+        }
+
+        @Test
+        void routeSourceImplementsInterface() {
+            var routeSource = staticFiles("/static", "/web");
+
+            assertThat(routeSource).isInstanceOf(RouteSource.class);
+            assertThat(routeSource).isInstanceOf(StaticFileRouteSource.class);
+        }
+    }
+
+    @Nested
+    class PathValidation {
+        @Test
+        void staticFilesCreatesValidRouteSource() {
+            var routeSource = staticFiles("/assets", "/public");
+            var routes = routeSource.routes().toList();
+
+            assertThat(routes).isNotEmpty();
+            assertThat(routes.getFirst().method()).isEqualTo(GET);
+        }
+    }
+
+    @Nested
+    class Integration {
+        @Test
+        void canBeUsedWithRequestRouter() {
+            var routeSource = staticFiles("/static", "/web");
+            var router = RequestRouter.with(routeSource);
+
+            var route = router.findRoute(GET, "/static/");
+            assertThat(route.isPresent()).isTrue();
+        }
+
+        @Test
+        void canBeUsedWithRoutePrefix() {
+            var routeSource = staticFiles("/files", "/resources").withPrefix("/api/v1");
+            var routes = routeSource.routes().toList();
+
+            assertThat(routes.getFirst().path()).isEqualTo("/api/v1/files/");
+        }
+
+        @Test
+        void canBeCombinedWithOtherRoutes() {
+            var staticRoutes = staticFiles("/static", "/web");
+            var apiRoute = Route.<String>get("/api/health")
+                                .to(_ -> org.pragmatica.lang.Promise.success("OK"))
+                                .asText();
+
+            var combined = RouteSource.of(staticRoutes, apiRoute);
+            var routes = combined.routes().toList();
+
+            assertThat(routes).hasSize(2);
+        }
+    }
+}

--- a/integrations/json/jackson/README.md
+++ b/integrations/json/jackson/README.md
@@ -8,7 +8,7 @@ Result-based JSON serialization/deserialization with Jackson 3.0.
 <dependency>
     <groupId>org.pragmatica-lite</groupId>
     <artifactId>jackson</artifactId>
-    <version>0.11.1</version>
+    <version>0.11.2</version>
 </dependency>
 ```
 

--- a/integrations/json/jackson/pom.xml
+++ b/integrations/json/jackson/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>json</artifactId>
         <groupId>org.pragmatica-lite</groupId>
-        <version>0.11.1</version>
+        <version>0.11.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integrations/json/pom.xml
+++ b/integrations/json/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>integrations</artifactId>
         <groupId>org.pragmatica-lite</groupId>
-        <version>0.11.1</version>
+        <version>0.11.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integrations/messaging/pom.xml
+++ b/integrations/messaging/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>integrations</artifactId>
         <groupId>org.pragmatica-lite</groupId>
-        <version>0.11.1</version>
+        <version>0.11.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integrations/metrics/micrometer/README.md
+++ b/integrations/metrics/micrometer/README.md
@@ -8,7 +8,7 @@ Aspect decorators for adding Micrometer metrics to Promise-returning functions.
 <dependency>
     <groupId>org.pragmatica-lite</groupId>
     <artifactId>micrometer</artifactId>
-    <version>0.11.1</version>
+    <version>0.11.2</version>
 </dependency>
 ```
 

--- a/integrations/metrics/micrometer/pom.xml
+++ b/integrations/metrics/micrometer/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>metrics</artifactId>
         <groupId>org.pragmatica-lite</groupId>
-        <version>0.11.1</version>
+        <version>0.11.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integrations/metrics/pom.xml
+++ b/integrations/metrics/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>integrations</artifactId>
         <groupId>org.pragmatica-lite</groupId>
-        <version>0.11.1</version>
+        <version>0.11.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integrations/net/dns/pom.xml
+++ b/integrations/net/dns/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>net</artifactId>
         <groupId>org.pragmatica-lite</groupId>
-        <version>0.11.1</version>
+        <version>0.11.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integrations/net/http-client/README.md
+++ b/integrations/net/http-client/README.md
@@ -8,7 +8,7 @@ Promise-based HTTP client wrapper around JDK HttpClient with typed error handlin
 <dependency>
     <groupId>org.pragmatica-lite</groupId>
     <artifactId>http-client</artifactId>
-    <version>0.11.1</version>
+    <version>0.11.2</version>
 </dependency>
 ```
 

--- a/integrations/net/http-client/pom.xml
+++ b/integrations/net/http-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>net</artifactId>
         <groupId>org.pragmatica-lite</groupId>
-        <version>0.11.1</version>
+        <version>0.11.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integrations/net/http-server/pom.xml
+++ b/integrations/net/http-server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>net</artifactId>
         <groupId>org.pragmatica-lite</groupId>
-        <version>0.11.1</version>
+        <version>0.11.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integrations/net/pom.xml
+++ b/integrations/net/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>integrations</artifactId>
         <groupId>org.pragmatica-lite</groupId>
-        <version>0.11.1</version>
+        <version>0.11.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integrations/net/tcp/pom.xml
+++ b/integrations/net/tcp/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>net</artifactId>
         <groupId>org.pragmatica-lite</groupId>
-        <version>0.11.1</version>
+        <version>0.11.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integrations/pom.xml
+++ b/integrations/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>pragmatica-lite</artifactId>
         <groupId>org.pragmatica-lite</groupId>
-        <version>0.11.1</version>
+        <version>0.11.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integrations/serialization/api/pom.xml
+++ b/integrations/serialization/api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>serialization</artifactId>
         <groupId>org.pragmatica-lite</groupId>
-        <version>0.11.1</version>
+        <version>0.11.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integrations/serialization/fury/pom.xml
+++ b/integrations/serialization/fury/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>serialization</artifactId>
         <groupId>org.pragmatica-lite</groupId>
-        <version>0.11.1</version>
+        <version>0.11.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integrations/serialization/kryo/pom.xml
+++ b/integrations/serialization/kryo/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>serialization</artifactId>
         <groupId>org.pragmatica-lite</groupId>
-        <version>0.11.1</version>
+        <version>0.11.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integrations/serialization/pom.xml
+++ b/integrations/serialization/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>integrations</artifactId>
         <groupId>org.pragmatica-lite</groupId>
-        <version>0.11.1</version>
+        <version>0.11.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integrations/utility/pom.xml
+++ b/integrations/utility/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>integrations</artifactId>
         <groupId>org.pragmatica-lite</groupId>
-        <version>0.11.1</version>
+        <version>0.11.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.pragmatica-lite</groupId>
     <artifactId>pragmatica-lite</artifactId>
-    <version>0.11.1</version>
+    <version>0.11.2</version>
     <modules>
         <module>core</module>
         <module>testing</module>
@@ -325,7 +325,7 @@
                 <plugin>
                     <groupId>org.pragmatica-lite</groupId>
                     <artifactId>jbct-maven-plugin</artifactId>
-                    <version>0.4.9</version>
+                    <version>0.5.0</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>pragmatica-lite</artifactId>
         <groupId>org.pragmatica-lite</groupId>
-        <version>0.11.1</version>
+        <version>0.11.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
## Summary
- Spacer-based route disambiguation in HTTP routing
- JBCT compliance fixes (extracted methods, stream-based operations)
- jbct-maven-plugin updated to 0.5.0

## Changes
- `PathParameter.spacer()` for literal path segment matching
- Routes with same base path but different spacers can coexist
- `RequestRouter` selects by spacer match with fallback
- Refactored imperative loops to stream-based operations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * HTTP routing supports spacer-based route disambiguation so multiple routes can share the same base path
  * Static file serving from classpath with automatic content-type detection and safe path handling
  * Consensus-aware leader election mode with asynchronous commit notifications

* **Bug Fixes**
  * Fixed path-parameter parsing edge cases (leading/trailing slash and empty remainder handling)

* **Documentation**
  * Project version references updated to 0.11.2 across docs and examples

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->